### PR TITLE
Some fixes, better notifications and file uri support

### DIFF
--- a/app/src/main/java/de/tubs/ibr/dtn/sharebox/DtnService.java
+++ b/app/src/main/java/de/tubs/ibr/dtn/sharebox/DtnService.java
@@ -38,6 +38,7 @@ import de.tubs.ibr.dtn.api.TransferMode;
 import de.tubs.ibr.dtn.sharebox.data.Database;
 import de.tubs.ibr.dtn.sharebox.data.Download;
 import de.tubs.ibr.dtn.sharebox.data.Download.State;
+import de.tubs.ibr.dtn.sharebox.data.PackageFile;
 import de.tubs.ibr.dtn.sharebox.data.TruncatedInputStream;
 import de.tubs.ibr.dtn.sharebox.data.Utils;
 
@@ -55,6 +56,15 @@ public class DtnService extends DTNIntentService {
     // download or rejet a bundle
     public static final String ACCEPT_DOWNLOAD_INTENT = "de.tubs.ibr.dtn.sharebox.ACCEPT_DOWNLOAD";
     public static final String REJECT_DOWNLOAD_INTENT = "de.tubs.ibr.dtn.sharebox.REJECT_DOWNLOAD";
+
+    // delete files or downloads
+    public static final String DELETE_ALL_INTENT = "de.tubs.ibr.dtn.sharebox.DELETE_ALL_INTENT";
+
+    public static final String DELETE_FILE_INTENT = "de.tubs.ibr.dtn.sharebox.DELETE_FILE_INTENT";
+    public static final String EXTRA_KEY_FILE_ID = "fileid";
+
+    public static final String DELETE_DOWNLOAD_INTENT = "de.tubs.ibr.dtn.sharebox.DELETE_DOWNLOAD_INTENT";
+    public static final String EXTRA_KEY_DOWNLOAD_ID = "downloadid";
     
     // local endpoint
     public static final String SHAREBOX_APP_ENDPOINT = "sharebox";
@@ -171,6 +181,34 @@ public class DtnService extends DTNIntentService {
             i.setAction(MARK_DELIVERED_INTENT);
             i.putExtra(EXTRA_KEY_BUNDLE_ID, bundleid);
             startService(i);
+        }
+        else if (DELETE_ALL_INTENT.equals(action))
+        {
+            // clear all entries in the database
+            mDatabase.clear();
+        }
+        else if (DELETE_DOWNLOAD_INTENT.equals(action))
+        {
+            Long id = intent.getLongExtra(EXTRA_KEY_DOWNLOAD_ID, 0);
+
+            // retrieve the bundle ID of the intent
+            BundleID bundleid = intent.getParcelableExtra(EXTRA_KEY_BUNDLE_ID);
+
+            // delete the download
+            mDatabase.remove(id);
+
+            // cancel notifications
+            mNotificationFactory.cancelDownload(bundleid);
+        }
+        else if (DELETE_FILE_INTENT.equals(action))
+        {
+            Long id = intent.getLongExtra(EXTRA_KEY_FILE_ID, 0);
+
+            // first get the correspondig file
+            PackageFile pf = mDatabase.getFile(id);
+
+            // remove the file
+            if (pf != null) mDatabase.remove(pf);
         }
         else if (ACCEPT_DOWNLOAD_INTENT.equals(action))
         {

--- a/app/src/main/java/de/tubs/ibr/dtn/sharebox/NotificationFactory.java
+++ b/app/src/main/java/de/tubs/ibr/dtn/sharebox/NotificationFactory.java
@@ -127,7 +127,6 @@ public class NotificationFactory {
     
     public void cancelDownload(BundleID bundleid) {
         mManager.cancel(bundleid.toString(), ONGOING_DOWNLOAD);
-        mDownloadBuilder = null;
     }
     
     /**

--- a/app/src/main/java/de/tubs/ibr/dtn/sharebox/NotificationFactory.java
+++ b/app/src/main/java/de/tubs/ibr/dtn/sharebox/NotificationFactory.java
@@ -109,6 +109,7 @@ public class NotificationFactory {
 
     public void showDownloadAborted(Download d) {
         // update notification
+        mDownloadBuilder.setContentTitle(mContext.getString(R.string.notification_aborted_download_title));
         mDownloadBuilder.setContentText(String.format(mContext.getString(R.string.notification_aborted_download_text), d.getBundleId().getSource()));
         mDownloadBuilder.setProgress(0, 0, false);
         mDownloadBuilder.setOngoing(false);
@@ -196,6 +197,7 @@ public class NotificationFactory {
 
     public void showUploadAborted(EID destination) {
         // update notification
+        mUploadBuilder.setContentTitle(mContext.getString(R.string.notification_aborted_upload_title));
         mUploadBuilder.setContentText(String.format(mContext.getString(R.string.notification_aborted_upload_text), destination.toString()));
         mUploadBuilder.setProgress(0, 0, false);
         mUploadBuilder.setOngoing(false);

--- a/app/src/main/java/de/tubs/ibr/dtn/sharebox/TarCreator.java
+++ b/app/src/main/java/de/tubs/ibr/dtn/sharebox/TarCreator.java
@@ -56,7 +56,8 @@ public class TarCreator implements Runnable {
 					currentFile++;
 					
 					// type not supported - skip the file
-					if (!ContentResolver.SCHEME_CONTENT.equals(uri.getScheme())) continue;
+					if (!ContentResolver.SCHEME_CONTENT.equals(uri.getScheme()))
+						throw new IllegalArgumentException("Content scheme " + uri.getScheme() + " not supported");
 					
 					ContentResolver resolver = mContext.getContentResolver();
 					

--- a/app/src/main/java/de/tubs/ibr/dtn/sharebox/data/Database.java
+++ b/app/src/main/java/de/tubs/ibr/dtn/sharebox/data/Database.java
@@ -283,12 +283,8 @@ public class Database {
                 // delete the file
                 f.delete();
 
-                // get content Uri for the deleted file
-                Uri contentUri = MediaStore.Audio.Media.getContentUriForPath( f.getAbsolutePath() );
-
                 // removed file from media library
-                mContext.getContentResolver().delete(contentUri,
-                        MediaStore.MediaColumns.DATA + " = ?", new String[]{f.getAbsolutePath()});
+                removeFromMediaStore(f);
             }
             
             cur.close();
@@ -310,12 +306,8 @@ public class Database {
     	// delete from storage
     	f.delete();
 
-        // get content Uri for the deleted file
-        Uri contentUri = MediaStore.Audio.Media.getContentUriForPath( f.getAbsolutePath() );
-    	
         // removed file from media library
-        mContext.getContentResolver().delete(contentUri,
-                MediaStore.MediaColumns.DATA + " = ?", new String[]{f.getAbsolutePath()});
+        removeFromMediaStore(f);
     	
     	notifyDataChanged();
     }
@@ -328,7 +320,7 @@ public class Database {
     
     public void remove(Long downloadId) {
         List<PackageFile> files = getFiles(downloadId);
-        
+
         // delete the files
         for (PackageFile pf : files) {
             File f = pf.getFile();
@@ -336,12 +328,8 @@ public class Database {
             // delete from storage
             f.delete();
 
-            // get content Uri for the deleted file
-            Uri contentUri = MediaStore.Audio.Media.getContentUriForPath(f.getAbsolutePath());
-
             // removed file from media library
-            mContext.getContentResolver().delete(contentUri,
-                    MediaStore.MediaColumns.DATA + " = ?", new String[]{f.getAbsolutePath()});
+            removeFromMediaStore(f);
         }
 
         // delete all files from database
@@ -351,5 +339,20 @@ public class Database {
         mDatabase.delete(Database.TABLE_NAMES[0], Download.ID + " = ?", new String[] { downloadId.toString() });
 
         notifyDataChanged();
+    }
+
+    private void removeFromMediaStore(File f) {
+        // get content Uri for the deleted file
+        Uri[] uris = {
+                MediaStore.Video.Media.EXTERNAL_CONTENT_URI,
+                MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+                MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+        };
+
+        for (Uri uri : uris) {
+            // removed file from media library
+            mContext.getContentResolver().delete(uri,
+                    MediaStore.MediaColumns.DATA + " = ?", new String[]{f.getAbsolutePath()});
+        }
     }
 }

--- a/app/src/main/java/de/tubs/ibr/dtn/sharebox/data/Database.java
+++ b/app/src/main/java/de/tubs/ibr/dtn/sharebox/data/Database.java
@@ -169,6 +169,26 @@ public class Database {
         
         return d;
     }
+
+    public PackageFile getFile(Long fileId) {
+        PackageFile ret = null;
+
+        try {
+            Cursor cur = mDatabase.query(Database.TABLE_NAMES[1], PackageFileAdapter.PROJECTION, PackageFile.ID + " = ?", new String[] { fileId.toString() }, null, null, null);
+
+            if (cur.moveToNext())
+            {
+                ret = new PackageFile(mContext, cur, new PackageFileAdapter.ColumnsMap());
+            }
+
+            cur.close();
+        } catch (Exception e) {
+            // error
+            Log.e(TAG, "getFile() failed", e);
+        }
+
+        return ret;
+    }
     
     public List<PackageFile> getFiles(Long downloadId) {
         LinkedList<PackageFile> files = new LinkedList<PackageFile>();

--- a/app/src/main/java/de/tubs/ibr/dtn/sharebox/ui/DownloadListFragment.java
+++ b/app/src/main/java/de/tubs/ibr/dtn/sharebox/ui/DownloadListFragment.java
@@ -107,11 +107,21 @@ public class DownloadListFragment extends ListFragment implements LoaderManager.
                                     // delete all selected items
                                     DownloadItem di = (DownloadItem)view;
                                     Download d = di.getObject();
-                
-                                    Intent rejectIntent = new Intent(getActivity(), DtnService.class);
-                                    rejectIntent.setAction(DtnService.REJECT_DOWNLOAD_INTENT);
-                                    rejectIntent.putExtra(DtnService.EXTRA_KEY_BUNDLE_ID, d.getBundleId());
-                                    getActivity().startService(rejectIntent);
+
+                                    if (d.isPending()) {
+                                        // reject download if the transmission if pending
+                                        Intent rejectIntent = new Intent(getActivity(), DtnService.class);
+                                        rejectIntent.setAction(DtnService.REJECT_DOWNLOAD_INTENT);
+                                        rejectIntent.putExtra(DtnService.EXTRA_KEY_BUNDLE_ID, d.getBundleId());
+                                        getActivity().startService(rejectIntent);
+                                    } else {
+                                        // otherwise simply delete it
+                                        Intent deleteIntent = new Intent(getActivity(), DtnService.class);
+                                        deleteIntent.setAction(DtnService.DELETE_DOWNLOAD_INTENT);
+                                        deleteIntent.putExtra(DtnService.EXTRA_KEY_DOWNLOAD_ID, d.getId());
+                                        deleteIntent.putExtra(DtnService.EXTRA_KEY_BUNDLE_ID, d.getBundleId());
+                                        getActivity().startService(deleteIntent);
+                                    }
                                 }
                             }
                         }
@@ -175,8 +185,9 @@ public class DownloadListFragment extends ListFragment implements LoaderManager.
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.itemClearList:
-                Database db = mService.getDatabase();
-                db.clear();
+                Intent clearIntent = new Intent(getActivity(), DtnService.class);
+                clearIntent.setAction(DtnService.DELETE_ALL_INTENT);
+                getActivity().startService(clearIntent);
                 return true;
             
             default:

--- a/app/src/main/java/de/tubs/ibr/dtn/sharebox/ui/PackageFileListFragment.java
+++ b/app/src/main/java/de/tubs/ibr/dtn/sharebox/ui/PackageFileListFragment.java
@@ -105,8 +105,10 @@ public class PackageFileListFragment extends ListFragment implements LoaderManag
                                     PackageFileItem pfi = (PackageFileItem)view;
                                     PackageFile pf = pfi.getObject();
 
-                                    Database db = mService.getDatabase();
-                                    db.remove(pf);
+                                    Intent deleteIntent = new Intent(getActivity(), DtnService.class);
+                                    deleteIntent.setAction(DtnService.DELETE_FILE_INTENT);
+                                    deleteIntent.putExtra(DtnService.EXTRA_KEY_FILE_ID, pf.getId());
+                                    getActivity().startService(deleteIntent);
                                 }
                             }
                         }

--- a/app/src/main/res/values/strings_notifications.xml
+++ b/app/src/main/res/values/strings_notifications.xml
@@ -6,17 +6,19 @@
     <string name="notification_ongoing_download_title">Transmission #%1$d</string>
     <string name="notification_ongoing_download_text">Receiving %1$s</string>
     <string name="notification_completed_download_text">Download complete (%1$s)</string>
-    <string name="notification_aborted_download_text">Download aborted</string>
+    <string name="notification_aborted_download_title">Transmission failed</string>
+    <string name="notification_aborted_download_text">Data is corrupted or expired</string>
     
-    <string name="notification_ongoing_upload_title">Transmission Upload</string>
+    <string name="notification_ongoing_upload_title">Transmission</string>
     <plurals name="notification_ongoing_upload_text">
         <item quantity="one">Wrap up %d file</item>
         <item quantity="other">Wrap up %d files</item>
     </plurals>
     
     <string name="notification_ongoing_upload_progress_text">%1$d / %2$d: %3$s</string>
-    <string name="notification_completed_upload_text">Upload complete (%1$s)</string>
-    <string name="notification_aborted_upload_text">Upload aborted</string>
+    <string name="notification_completed_upload_text">Preparation complete (%1$s)</string>
+    <string name="notification_aborted_upload_title">Transmission failed</string>
+    <string name="notification_aborted_upload_text">Unsupported media or missing file-permissions</string>
 
     <plurals name="notification_pending_download_title">
         <item quantity="one">Transmission #%2$d (%3$s)</item>


### PR DESCRIPTION
This patch-set adds support for file scheme uris. Some applications use them instead of content uris (e.g. ES Explorer). Now, such share requests are also supported. Moreover, we change the text of notifications in case of an failure. Now non-existing files and missing permissions result in an aborted transmission. Finally, deleted files are also removed from media stores for video and images.
