### PR TITLE
Synchronize intent processing in DtnService

### DIFF
--- a/app/src/main/java/de/tubs/ibr/dtn/sharebox/DtnService.java
+++ b/app/src/main/java/de/tubs/ibr/dtn/sharebox/DtnService.java
@@ -129,7 +129,7 @@ public class DtnService extends DTNIntentService {
     }
     
     @Override
-    protected void onHandleIntent(Intent intent) {
+    protected synchronized void onHandleIntent(Intent intent) {
         String action = intent.getAction();
         
         if (de.tubs.ibr.dtn.Intent.RECEIVE.equals(action))


### PR DESCRIPTION
Although the intents should be processed sequentially, there
seems to be platforms which behave differently. A synchronized statement
limit the processing to one intent after another.

This patch is related to issue #6.
